### PR TITLE
Removed geo_shape PrefixTree

### DIFF
--- a/packages/api-lib/libs/es.js
+++ b/packages/api-lib/libs/es.js
@@ -122,7 +122,6 @@ async function prepare(index) {
               'properties': props,
               geometry: {
                 type: 'geo_shape',
-                tree: 'quadtree',
                 precision: precision
               }
             }


### PR DESCRIPTION
Removed the prefix tree from the geometry object.