### PR TITLE
Improve partial item editing / enabling of Transactions extensions

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,6 +47,7 @@ There are some settings that should be reviewed and updated as needeed in the [s
 | ES_BATCH_SIZE | Number of records to ingest in single batch | 500 |
 | LOG_LEVEL | Level for logging (CRITICAL, ERROR, WARNING, INFO, DEBUG) | INFO |
 | STAC_API_URL | The root endpoint of this API | Inferred from request |
+| ENABLE_TRANSACTIONS_EXTENSION | Boolean specifying if the [Transaction Extension](https://github.com/radiantearth/stac-api-spec/tree/master/extensions/transaction) should be activated | false |
 
 After reviewing the settings, build and deploy the project.
 

--- a/lambdas/api/index.js
+++ b/lambdas/api/index.js
@@ -1,5 +1,6 @@
 const satlib = require('../../libs')
 const logger = console
+const httpMethods = require('../../utils/http-methods')
 
 
 function determineEndpoint(event) {
@@ -20,10 +21,10 @@ function determineEndpoint(event) {
 function buildRequest(event) {
   const method = event.httpMethod
   let query = {}
-  if (method === 'POST' && event.body) {
-    query = JSON.parse(event.body)
-  } else if (method === 'GET' && event.queryStringParameters) {
+  if (method === httpMethods.GET && event.queryStringParameters) {
     query = event.queryStringParameters
+  } else if (event.body) {
+    query = JSON.parse(event.body)
   }
   return query
 }
@@ -44,7 +45,7 @@ module.exports.handler = async (event) => {
   logger.debug(`Event: ${JSON.stringify(event)}`)
   const endpoint = determineEndpoint(event)
   const query = buildRequest(event)
-  const result = await satlib.api.API(event.path, query, satlib.es, endpoint)
+  const result = await satlib.api.API(event.path, query, satlib.es, endpoint, event.httpMethod)
   return result instanceof Error ?
     buildResponse(404, result.message) :
     buildResponse(200, JSON.stringify(result))

--- a/serverless.yml
+++ b/serverless.yml
@@ -15,6 +15,7 @@ provider:
     STAC_DOCS_URL: https://stac-utils.github.io/stac-api/
     ES_HOST:
       Fn::GetAtt: [ElasticSearchInstance, DomainEndpoint]
+    ENABLE_TRANSACTIONS_EXTENSION: true
   iamRoleStatements:
     - Effect: "Allow"
       Resource: "arn:aws:es:#{AWS::Region}:#{AWS::AccountId}:domain/*"

--- a/serverless.yml
+++ b/serverless.yml
@@ -15,7 +15,6 @@ provider:
     STAC_DOCS_URL: https://stac-utils.github.io/stac-api/
     ES_HOST:
       Fn::GetAtt: [ElasticSearchInstance, DomainEndpoint]
-    ENABLE_TRANSACTIONS_EXTENSION: true
     ENABLE_TRANSACTIONS_EXTENSION: false
   iamRoleStatements:
     - Effect: "Allow"

--- a/serverless.yml
+++ b/serverless.yml
@@ -16,6 +16,7 @@ provider:
     ES_HOST:
       Fn::GetAtt: [ElasticSearchInstance, DomainEndpoint]
     ENABLE_TRANSACTIONS_EXTENSION: true
+    ENABLE_TRANSACTIONS_EXTENSION: false
   iamRoleStatements:
     - Effect: "Allow"
       Resource: "arn:aws:es:#{AWS::Region}:#{AWS::AccountId}:domain/*"

--- a/utils/http-methods.js
+++ b/utils/http-methods.js
@@ -1,0 +1,7 @@
+module.exports = {
+  GET: 'GET',
+  POST: 'POST',
+  PUT: 'PUT',
+  DELETE: 'DELETE',
+  PATCH: 'PATCH'
+}


### PR DESCRIPTION
# Background

My overall goal was to change from a:

`POST /collections/<collectionId>/items/<itemId>/edit`

to

`PATCH /collections/<collectionId>/items/<itemId>`

Which was more RESTful and also conforms to the stac-api's Transaction specification: https://github.com/radiantearth/stac-api-spec/tree/master/extensions/transaction

An /edit path is more traditionally used to render a HTML form which eventually will post to a PUT/PATCH endpoint.

# What's Includes

I also adjusted aspects of areas I was touching directly:

- The above route change
- Ability to easily toggle whether Transaction extension endpoints are available
- Simple HTTP constant utils introduced
- Fixed a bug where we required a blank `properties` param even if not are being modified

# Explanation of changes

We have a DIY routing approach inside api.js. Previously it was working with paths only, so I added support for also recognizing the HTTP method when it comes to determining different behavior for identical paths.

I found myself working in several cases with inline string literals for HTTP methods. I'd rather use constants and symbols, so I made a really minimal util to provide this.

I introduced a way to easily toggle the transaction endpoints, driven by an environment variable. I also instructions to the README regarding this.

Finally, I fixed an issue that required callers to specify a blank `properties` param even if none are being modified. The problem before was the edit endpoint trying to set an `updatedAt` date inside this object, and if it was nil there'd be an exception.

# Testing

The new behavior is triggered during a call to:

`PATCH /collections/<collectionId>/items/<itemId>`

Which is primarily used to change the collection of an item. Sample bodies include:

```
{
  "collection": "new-collection"
}
```

or with other properties

```
{
  "collection": "new-collection",
  "properties": {
    "some-other-property": true
  }
}
```

- `properties` will always get an `updated` attribute automatically assigned to the current date.
  - If other attributes are alongside in this object, it's merged with them.
  - If the input tries to provide updated as one of those attributes, ours is overwritten.
  - If no properties object is provided, we default to one with only `updated`

-----

It's probably also worth testing other http methods on this same route, such as:

`GET /collections/<collectionId>/items/<itemId>`

# Toggling the Transactions extensions

See the note in README, but essentially this is driven by a boolean ENV setting in serverless.yml.  Previously we relied on commenting code, and moreover a code commit to change it.